### PR TITLE
死亡日が--のときインサートされない不具合を修正　また、死亡日が不明の時9999-01-01になるように修正　また、コアラを追加するときに…

### DIFF
--- a/src/main/java/com/example/demo/app/CoaraController.java
+++ b/src/main/java/com/example/demo/app/CoaraController.java
@@ -88,9 +88,6 @@ public class CoaraController {
 			return getInsert(model,form);
 		}
 		service.insert(form);
-		List<Coara> list = coaraService.getAll();
-		model.addAttribute("coaraList", list);
-		model.addAttribute("title","コアラ一覧");
 		return "redirect:/search";
 
 	}

--- a/src/main/java/com/example/demo/app/CoaraInsertForm.java
+++ b/src/main/java/com/example/demo/app/CoaraInsertForm.java
@@ -14,20 +14,20 @@ public class CoaraInsertForm {
 	@Max(1)
 	private int is_alive = 1;
 	
-	private int sex=2;
+	private int sex = 2;
 
-  
+	@NotBlank
 	private String birthYear = "2000";
 	@NotBlank
-	private String birthMonth;
+	private String birthMonth = "1";
 	@NotBlank
-	private String birthDay;
+	private String birthDay = "1";
 	@NotBlank
-	private String deathYear;
+	private String deathYear = "0";
 	@NotBlank
-	private String deathMonth;
+	private String deathMonth = "0";
 	@NotBlank
-	private String deathDay;
+	private String deathDay= "0";
 	@NotBlank
 	private String zoo;
 	@NotBlank

--- a/src/main/java/com/example/demo/service/CoaraServiceImpl.java
+++ b/src/main/java/com/example/demo/service/CoaraServiceImpl.java
@@ -52,6 +52,13 @@ public class CoaraServiceImpl implements CoaraService{
 	
 	public Date getDate(String year , String month , String day){
 		String hyphen = "-";
+		//年、月、日の中に"--"が含まれていたら、"9999-01-01"を返す。
+		String dummyValue = "0";
+		if(year.equals(dummyValue) || month.equals(dummyValue) || day.equals(dummyValue)) {
+			year = "9999";
+			month = "01";
+			day = "01";
+		}
 		StringBuilder sb = new StringBuilder();
 		sb.append(year);
 		sb.append(hyphen);

--- a/src/main/resources/templates/insert.html
+++ b/src/main/resources/templates/insert.html
@@ -59,26 +59,28 @@
 				birthZeroCount++;
 			}
 		}
-
+		
 		let deathZeroCount = 0;
 		for (let i = 0; i < death.length; i++) {
 			if (death[i] == 0) {
 				deathZeroCount++;
 			}
 		}
-
+		
 		let birthFlag = true;
 		if (1 <= birthZeroCount && birthZeroCount <= 2) {
 			alert('生年月日が不正です。');
 			birthFlag = false;
 		}
-
-		let deathFlag = true;
-		if (1 <= deathZeroCount && deathZeroCount <= 2) {
-			alert('死亡日が不正です。');
-			deathFlag = false;
-		}
 		
+		const birthDate = parseInt(birthYear + birthMonth + birthDay);
+		const deathDate = parseInt(deathYear + deathMonth + deathDay);
+		let deathFlag = true;
+		if ((1 <= deathZeroCount && deathZeroCount <= 2) || (birthDate > deathDate)) {
+			alert('死亡日が不正です。');
+			deathFlag = false;	
+		}
+		  
 		let detailsFlag = true;
 		if(!$this.elements["details"].value){
 			alert('詳細を入力してください。');
@@ -90,7 +92,7 @@
 			alert('特徴を入力してください。');
 			featureFlag = false;
 		}
-		alert(ameFlag && birthFlag && deathFlag && detailsFlag && featureFlag) ;
+		
 		if (nameFlag && birthFlag && deathFlag && detailsFlag && featureFlag) {
 			return true;
 		} else {
@@ -131,12 +133,15 @@
 			</div>
 					<div class="form-group">
 					生年月日：<select th:field="*{birthYear}">
+					<option value="0">--</option>
 						<option th:each="i : ${#numbers.sequence(1900, 2021)}"
 							th:value="${i}" th:text="${i}" ></option>
 					</select>年 <select th:field="*{birthMonth}">
+					<option value="0">--</option>
 						<option th:each="i : ${#numbers.sequence(1, 12)}" th:value="${i}"
 							th:text="${i}"></option>
 					</select>月 <select th:field="*{birthDay}">
+					<option value="0">--</option>
 						<option th:each="i : ${#numbers.sequence(1, 31)}" th:value="${i}"
 							th:text="${i}"></option>
 					</select>日


### PR DESCRIPTION
死亡日が--のときインサートされない不具合を修正　
また、死亡日が不明の時9999-01-01になるように修正　
また、コアラを追加するときに死亡日が誕生日と比べて不正だった場合、アラートを出して追加できないように
javascriptを修正